### PR TITLE
Disable image on blog overview

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -9,7 +9,7 @@ layout: default
 			{% for post in site.posts offset: 0 limit: 4 %}
 			<div class="row">
 				<section class="8u -2u">
-					<a href="{{ site.prefix }}{{ post.url }}" class="image full"><img src="/assets/{{ post.featured }}" alt=""></a>
+					<!-- <a href="{{ site.prefix }}{{ post.url }}" class="image full"><img src="/assets/{{ post.featured }}" alt=""></a> -->
 					<header>
 						<h2>{{ post.title }}</h2>
 					</header>


### PR DESCRIPTION
Not sure what these images are for exactly, I assume we could use them in the future. However, they serve us no purpose at the moment.
