### PR TITLE
Revert "Update 2015-12-12-swift.md"

### DIFF
--- a/_posts/2015-12-12-swift.md
+++ b/_posts/2015-12-12-swift.md
@@ -9,7 +9,9 @@ tags: swift apple tutorial compile
 One might think compiling Apple Swift on FreeBSD might be a bit of a hassle, but because it uses the LLVM framework it really isn't! There currently isn't a port for it, although I might make one soon, but there is a [`sh` script](https://github.com/zebMcCorkle/swift-freebsd) on my GitHub that does the whole process for you. Here, I describe the process I took to make those instructions (because for some reason Apple's guide for compiling for Linux are incomplete?)
 
 # Step 1 - Install dependencies
+
 There are minimal dependencies for Swift, at least on my system they were all installed. The Apple guide has a list of dependencies for Ubuntu, so I turned that into a list of ports you need:
+
  - `devel/git`
  - `devel/cmake`
  - `lang/clang37`
@@ -20,11 +22,14 @@ If it doesn't compile on your system with just these dependencies, feel free to 
 # Step 2 - Download other dependencies and set up build environment
 
 Swift requires some other dependencies than just the binary ones you installed last step, so we'll set up a building folder in `~` with the dependencies.
+
 ```
 mkdir ~/building
 cd ~/building
 ```
+
 Now, we'll download the dependencies
+
 ```
 wget http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz -O- | tar -xvf -
 wget http://llvm.org/releases/3.7.0/cfe-3.7.0.src.tar.xz -O- | tar -xvf -
@@ -36,21 +41,28 @@ rm -rf llvm-3.7.0.src cfe-3.7.0.src
 ```
 
 # Step 3 - Download Swift
+
 Now that we have the dependencies, we now have to download the Swift source code. I'm going to clone the current `master` branch, as Swift follows GitHub flow and `master` is always deployable.
+
 ```
 git clone https://github.com/apple/swift # or, if you have the hub utility: hub clone apple/swift
 ```
 
 # Step 4 - Compile Swift
+
 This is the easiest part. We simply have to run a shell script that compiles Swift for us.
+
 ```
 cd swift
 utils/build-script
 ```
 
 # Step 5 - Celebrate
+
 Congratulations! You've compiled Swift! I'm now going to turn each line of code in this blog post into a shell script and post it on my GitHub so you can just run that like this:
+
 ```
 wget https://raw.githubusercontent.com/zebMcCorkle/swift-freebsd/master/install.sh -O- | sh -
 ```
+
 This script, however, will not install the dependencies from ports.


### PR DESCRIPTION
Reverts ID10T-Errors/ID10T-Errors.github.io#40

It broke everything.

> There are minimal dependencies for Swift, at least on my system they were all installed. The Apple guide has a list of dependencies for Ubuntu, so I turned that into a list of ports you need: `- devel/git - devel/cmake - lang/clang37 - lang/python2`

and

> Swift requires some other dependencies than just the binary ones you installed last step, so we’ll set up a building folder in `~` with the dependencies. `mkdir ~/building cd ~/building` Now, we’ll download the dependencies `wget http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz -O- | tar -xvf - wget http://llvm.org/releases/3.7.0/cfe-3.7.0.src.tar.xz -O- | tar -xvf - mkdir llvm cp -R llvm-3.7.0.src/* llvm/ mkdir clang cp -R cfe-3.7.0.src/* clang/ rm -rf llvm-3.7.0.src cfe-3.7.0.src`
