### PR TITLE
Change the syntax highlighting theme to a darker one

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,7 @@ Released for free under the Creative Commons Attribution 3.0 license (templated.
 		<link rel="stylesheet" href="/assets/css/style-desktop.css" />
 	</noscript>
 
-	<link rel="stylesheet" crossorigin="anonymous" integrity="sha256-44JTc18j6+VlpxPhZ5wk7GgzFFgAVMGzORCJ2xUEOzs=" href="https://cdn.jsdelivr.net/prism/1.3.0/themes/prism.css">
+	<link rel="stylesheet" crossorigin="anonymous" integrity="sha256-g68w94SgvezsIHQT8uuYqjqm5vNxpt6rfYXxq1sRuZY=" href="https://cdn.jsdelivr.net/prism/1.3.0/themes/prism-tomorrow.css">
 	<script src="https://cdn.jsdelivr.net/prism/1.3.0/prism.js"></script>
 
 	<style>


### PR DESCRIPTION
I feel it fits with the site's theme better and the contrast with the main page background works IMO.
